### PR TITLE
Remove duplicate section

### DIFF
--- a/lib/Mojolicious/Plugin/SecurityHeader.pm
+++ b/lib/Mojolicious/Plugin/SecurityHeader.pm
@@ -1,4 +1,5 @@
 package Mojolicious::Plugin::SecurityHeader;
+# ABSTRACT: Mojolicious Plugin
 use Mojo::Base 'Mojolicious::Plugin';
 
 our $VERSION = '0.03';

--- a/lib/Mojolicious/Plugin/SecurityHeader.pm
+++ b/lib/Mojolicious/Plugin/SecurityHeader.pm
@@ -160,10 +160,6 @@ __END__
 
 =encoding utf8
 
-=head1 NAME
-
-Mojolicious::Plugin::SecurityHeader - Mojolicious Plugin
-
 =head1 SYNOPSIS
 
   # Mojolicious


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.

It try to address 2 things:
   a) [PodWeaver] [@Default/Name] couldn't find abstract in lib/Mojolicious/Plugin/SecurityHeader.pm
   b) Duplicate section NAME in the pod

I didn't know PodWeaver gives NAME section for free if you have "#ABSTRACT" in your pod. In case of missing, it is still adds incomplete NAME section. So better give what it needs to generate NAME section correctly and not bother adding yourself.

Many Thanks.
Best Regards,
Mohammad S Anwar